### PR TITLE
Fix Render deployment service_id error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,6 +101,7 @@ jobs:
         EOL
     
     - name: Deploy to Render
+      if: ${{ env.RENDER_SERVICE_ID != '' && env.RENDER_API_KEY != '' }}
       uses: JorgeLNJunior/render-deploy@v1.4.3
       with:
         service_id: ${{ secrets.RENDER_SERVICE_ID }}
@@ -110,3 +111,5 @@ jobs:
         web_deploy: true
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+        RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to handle missing Render service_id:

- Added conditional check to skip Render deployment if service_id is not provided
- Added environment variables to properly check for the existence of the service_id
- Allows the frontend to deploy to GitHub Pages even when Render deployment is skipped

Link to Devin run: https://app.devin.ai/sessions/b957d6c4a4d6406db7df009b0b8cf43b
Requested by: roxie.reginold@rbc.com